### PR TITLE
No need to create eyewitness output dir manually

### DIFF
--- a/reconky.sh
+++ b/reconky.sh
@@ -50,9 +50,6 @@ if [ ! -d '$target/reconky/amass' ]; then
 	mkdir $target/reconky/amass
 	touch $target/reconky/amass/subdomains2.txt
 fi
-if [ ! -d '$target/reconky/witness' ]; then
-	mkdir $target/reconky/eyewitness
-fi
 if [ ! -d '$target/reconky/knockpy' ]; then
 	mkdir $target/reconky/knockpy
 	touch $target/reconky/knockpy/subdomains3.txt


### PR DESCRIPTION
Removing the mkdir command to create the eyewitness output directory previously.
 ---- The "-d " argument in eyewitness command in the last line of the script creates automatically the output directory. Removing the mkdir command avoid the script to be waiting for the following action "Directory Exists! Do you want to overwrite? [y/n]", finishing the execution directly in case of running again the scan for the same domain.